### PR TITLE
fix mgo decoding struct{ id *primitive.ObjectID }

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -667,7 +667,13 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		switch inv.Kind() {
 		case reflect.String:
 			slice := []byte(inv.String())
-			out.Set(reflect.ValueOf(slice))
+			if outt == typePrimObjectId {
+				p := primitive.ObjectID{}
+				copy(p[:], slice)
+				out.Set(reflect.ValueOf(p))
+			} else {
+				out.Set(reflect.ValueOf(slice))
+			}
 			return true
 		case reflect.Slice:
 			switch outt.Kind() {

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -43,13 +43,21 @@ func TestMarshal_ObjectID(t *testing.T) {
 	// old driver will take the pointer to zero as a 00000 id.
 	// t.Run("zero id", func(t *testing.T) {
 	// 	id := primitive.ObjectID{}
-
 	// 	p := PStructPointer{ID: &id}
-
 	// 	i := ObjectIdHex(id.Hex())
 	// 	b := BStructPointer{ID: &i}
-	// 	checkMarshal(t, p, b, false)
+	// 	CheckMarshalAndUnmarshal(t, p, b)
 	// })
+
+	t.Run("not-zero pointer id", func(t *testing.T) {
+		id := primitive.NewObjectID()
+		p := PStructPointer{ID: &id}
+
+		i := ObjectIdHex(id.Hex())
+		b := BStructPointer{ID: &i}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
 
 	t.Run("nil id", func(t *testing.T) {
 		p := PStructPointer{ID: nil}


### PR DESCRIPTION
The problem was mgo having trouble with structs like:
```
type Thing struct {
  ID primitive.ObjectID
  Optional *primitive.ObjectID
}
```

Note if you have
```
type Thing struct {
  ID bson.ObjectId
  Optional *bson.ObjectId
}
```
it's all good because mgo supports itself. 
