### PR TITLE
fix omit empty for primitive.ObjectID with mgo marshalling

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -173,6 +173,11 @@ func isZero(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.String:
 		return len(v.String()) == 0
+	case reflect.Array:
+		if v.Type() == typePrimObjectId {
+			return v.Interface().(primitive.ObjectID) == primitive.NilObjectID
+		}
+		panic(fmt.Sprintf("unknown type: %v", v.Type()))
 	case reflect.Ptr, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice:
@@ -202,6 +207,7 @@ func isZero(v reflect.Value) bool {
 		}
 		return true
 	}
+
 	return false
 }
 

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -39,13 +39,22 @@ func TestMarshal_ObjectID(t *testing.T) {
 		CheckMarshalAndUnmarshal(t, p, b)
 	})
 
-	// new driver will consider a pointer to zero value as empty
-	// old driver will take the pointer to zero as a 00000 id.
-	// t.Run("zero id", func(t *testing.T) {
+	t.Run("zero id", func(t *testing.T) {
+		p := PStruct{}
+		b := BStruct{}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
+
+	// this actually works but is hard to test.
+	// pointer to empty value will be empty
+	// t.Run("zero id pointer", func(t *testing.T) {
 	// 	id := primitive.ObjectID{}
 	// 	p := PStructPointer{ID: &id}
-	// 	i := ObjectIdHex(id.Hex())
+
+	// 	i := ObjectId("")
 	// 	b := BStructPointer{ID: &i}
+
 	// 	CheckMarshalAndUnmarshal(t, p, b)
 	// })
 


### PR DESCRIPTION
another case, "IsZero" did not know what to do with primitive.ObjectID
```
struct {
 ID primitive.ObjectID `bson:"_id,omitempty"`
}
```
would previously marshal to an id with all 000000000000000000000000