### PR TITLE
nil value into ObjectID should set to empty

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -305,6 +305,12 @@ func (id ObjectId) MarshalBSONValue() (bsontype.Type, []byte, error) {
 
 func (id *ObjectId) UnmarshalBSONValue(t bsontype.Type, raw []byte) error {
 	s := hex.EncodeToString(raw[:])
+
+	if raw == nil {
+		*id = ObjectId("")
+		return nil
+	}
+
 	if !IsObjectIdHex(s) {
 		return fmt.Errorf("invalid ObjectId: %s", raw)
 	}


### PR DESCRIPTION
nil into a return ObjectId should work and just set the value to empty.

Previously the new driver was erroring on this case.  