### PR TITLE
bson.MarshalJSON to marshal primitive.ObjectID like bson.ObjectId

### DIFF
--- a/bson/json.go
+++ b/bson/json.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"gopkg.in/mgo.v2/internal/json"
 	"strconv"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"gopkg.in/mgo.v2/internal/json"
 )
 
 // UnmarshalJSON unmarshals a JSON value that may hold non-standard
@@ -74,6 +76,7 @@ func init() {
 	jsonExt.DecodeKeyed("$oid", jdecObjectId)
 	jsonExt.DecodeKeyed("$oidFunc", jdecObjectId)
 	jsonExt.EncodeType(ObjectId(""), jencObjectId)
+	jsonExt.EncodeType(primitive.ObjectID{}, jencObjectId)
 
 	funcExt.DecodeFunc("DBRef", "$dbrefFunc", "$ref", "$id")
 	jsonExt.DecodeKeyed("$dbrefFunc", jdecDBRef)
@@ -259,8 +262,12 @@ func jdecObjectId(data []byte) (interface{}, error) {
 	return ObjectIdHex(v.Id), nil
 }
 
+type hexer interface {
+	Hex() string
+}
+
 func jencObjectId(v interface{}) ([]byte, error) {
-	return fbytes(`{"$oid":"%s"}`, v.(ObjectId).Hex()), nil
+	return fbytes(`{"$oid":"%s"}`, v.(hexer).Hex()), nil
 }
 
 func jdecDBRef(data []byte) (interface{}, error) {

--- a/bson/json_test.go
+++ b/bson/json_test.go
@@ -1,13 +1,42 @@
 package bson_test
 
 import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"gopkg.in/mgo.v2/bson"
 
 	. "gopkg.in/check.v1"
-	"reflect"
-	"strings"
-	"time"
 )
+
+func TestMarshalJSON_objectIDs(t *testing.T) {
+	id1 := bson.NewObjectId()
+	id2 := primitive.NewObjectID()
+
+	// encode
+	dataB, err := bson.MarshalJSON(bson.M{"id1": id1, "id2": id2})
+	if err != nil {
+		t.Fatalf("marshal json error: %v", err)
+	}
+
+	dataP, err := bson.MarshalJSON(primitive.M{"id1": id1, "id2": id2})
+	if err != nil {
+		t.Fatalf("marshal json error: %v", err)
+	}
+
+	if !bytes.Equal(dataB, dataP) {
+		t.Errorf("unequal bytes: %s %s", dataB, dataP)
+	}
+
+	expected := `{"id1":{"$oid":"` + id1.Hex() + `"},"id2":{"$oid":"` + id2.Hex() + `"}}` + "\n"
+	if string(dataB) != expected {
+		t.Errorf("unequal bytes: got: %s expected: %s", dataB, expected)
+	}
+}
 
 type jsonTest struct {
 	a interface{} // value encoded into JSON (optional)


### PR DESCRIPTION
object ids are marshaled as `{"$oid":"6580a79827476fd60760c809"}`, Should be same behavior for new and old types