### PR TITLE
bson.MarshalJSON to marshal primitive.DateTime like time.Time

### DIFF
--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
@@ -149,6 +150,45 @@ func TestMarshal_Regex(t *testing.T) {
 		b := BStructPointer{Regex: nil}
 		CheckMarshal(t, p, b)
 	})
+}
+
+func TestMarshal_time(t *testing.T) {
+	now := time.Now().UTC()
+
+	dataB, err := Marshal(bson.M{"time": now})
+	if err != nil {
+		t.Fatalf("marshal bson error: %v", err)
+	}
+
+	dataP, err := bson.Marshal(primitive.M{"time": now})
+	if err != nil {
+		t.Fatalf("marshal bson error: %v", err)
+	}
+
+	if !bytes.Equal(dataB, dataP) {
+		t.Errorf("unequal bytes: %s %s", dataB, dataP)
+	}
+
+	// unmarshal
+	type Struct struct {
+		Time time.Time `bson:"time"`
+	}
+
+	b := Struct{}
+	err = Unmarshal(dataB, &b)
+	if err != nil {
+		t.Fatalf("unmarshal bson error: %v", err)
+	}
+
+	p := Struct{}
+	err = bson.Unmarshal(dataB, &p)
+	if err != nil {
+		t.Fatalf("unmarshal bson error: %v", err)
+	}
+
+	if !b.Time.UTC().Equal(p.Time.UTC()) {
+		t.Errorf("unequal time: %s %s", b.Time.UTC(), p.Time.UTC())
+	}
 }
 
 func TestMarshal_M(t *testing.T) {

--- a/bson/json.go
+++ b/bson/json.go
@@ -62,6 +62,7 @@ func init() {
 	jsonExt.DecodeKeyed("$date", jdecDate)
 	jsonExt.DecodeKeyed("$dateFunc", jdecDate)
 	jsonExt.EncodeType(time.Time{}, jencDate)
+	jsonExt.EncodeType(primitive.DateTime(0), jencDate)
 
 	funcExt.DecodeFunc("Timestamp", "$timestamp", "t", "i")
 	jsonExt.DecodeKeyed("$timestamp", jdecTimestamp)
@@ -201,7 +202,10 @@ func jdecDate(data []byte) (interface{}, error) {
 }
 
 func jencDate(v interface{}) ([]byte, error) {
-	t := v.(time.Time)
+	t, ok := v.(time.Time)
+	if !ok {
+		t = v.(primitive.DateTime).Time()
+	}
 	return fbytes(`{"$date":%q}`, t.Format(jdateFormat)), nil
 }
 

--- a/bson/json_test.go
+++ b/bson/json_test.go
@@ -38,6 +38,24 @@ func TestMarshalJSON_objectIDs(t *testing.T) {
 	}
 }
 
+func TestMarshalJSON_time(t *testing.T) {
+	t1 := time.Now()
+	t2 := primitive.NewDateTimeFromTime(t1)
+
+	// encode
+	data, err := bson.MarshalJSON(primitive.M{"t1": t1, "t2": t2})
+	if err != nil {
+		t.Fatalf("marshal json error: %v", err)
+	}
+
+	const jdateFormat = "2006-01-02T15:04:05.999Z"
+	expected := `{"t1":{"$date":"` + t1.Format(jdateFormat) + `"},` +
+		`"t2":{"$date":"` + t2.Time().Format(jdateFormat) + `"}}` + "\n"
+	if string(data) != expected {
+		t.Errorf("unequal bytes: got: %s expected: %s", data, expected)
+	}
+}
+
 type jsonTest struct {
 	a interface{} // value encoded into JSON (optional)
 	b string      // JSON expected as output of <a>, and used as input to <c>


### PR DESCRIPTION
times should marshal as `{"$date":"2023-12-18T12:52:26.131Z"}`

new driver pulls time from db into primitive.DateTime by default, old one pulls it into time.Time.