### PR TITLE
Support Timestamp type by both drivers

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -436,6 +436,21 @@ func Now() time.Time {
 // strange reason has its own datatype defined in BSON.
 type MongoTimestamp int64
 
+// UnmarshalBSONValue is used by the new driver to set this type/value.
+func (mt *MongoTimestamp) UnmarshalBSONValue(t bsontype.Type, raw []byte) error {
+	if t != bsontype.Timestamp {
+		return fmt.Errorf("BSON type is not a timestamp: %v", t)
+	}
+	*mt = MongoTimestamp(int64(binary.LittleEndian.Uint64(raw)))
+	return nil
+}
+
+func (mt MongoTimestamp) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	v := make([]byte, 8)
+	binary.LittleEndian.PutUint64(v, uint64(mt))
+	return bsontype.Timestamp, v, nil
+}
+
 type orderKey int64
 
 // MaxKey is a special value that compares higher than all other possible BSON

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -761,6 +761,20 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 			out.Set(reflect.ValueOf(u).Elem())
 			return true
 		}
+
+		if outt == typePrimTimestamp {
+			if t, ok := in.(MongoTimestamp); ok {
+				ti := uint64(t)
+				out.Set(
+					reflect.ValueOf(
+						primitive.Timestamp{T: uint32(ti >> 32), I: uint32(ti & ((1 << 32) - 1))},
+					),
+				)
+
+				return true
+			}
+		}
+
 		if outt == typeBinary {
 			if b, ok := in.([]byte); ok {
 				out.Set(reflect.ValueOf(Binary{Data: b}))

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -49,6 +49,7 @@ var (
 	typeDBPointer      = reflect.TypeOf(DBPointer{"", ObjectId("")})
 	typeSymbol         = reflect.TypeOf(Symbol(""))
 	typeMongoTimestamp = reflect.TypeOf(MongoTimestamp(0))
+	typePrimTimestamp  = reflect.TypeOf(primitive.Timestamp{})
 	typeOrderKey       = reflect.TypeOf(MinKey)
 	typeDocElem        = reflect.TypeOf(DocElem{})
 	typePrimDoc        = reflect.TypeOf(primitive.D{})
@@ -449,6 +450,14 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			e.addElemName(0x0B, name)
 			e.addCStr(s.Pattern)
 			e.addCStr(s.Options)
+
+		case primitive.Timestamp:
+			e.addElemName(0x11, name)
+
+			var v int64
+			v |= int64(s.T) << 32
+			v |= int64(s.I)
+			e.addInt64(v)
 
 		case JavaScript:
 			if s.Scope == nil {

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -191,6 +191,77 @@ func TestMarshal_time(t *testing.T) {
 	}
 }
 
+func TestMarshal_Timestamp(t *testing.T) {
+	nano := time.Now().Unix()
+
+	// first 4 bytes (T) is timestamp
+	// second 4 bytes (I) is increment
+
+	t.Run("non-pointer", func(t *testing.T) {
+		type PStruct struct {
+			Time primitive.Timestamp `bson:"time"`
+		}
+
+		type BStruct struct {
+			Time MongoTimestamp `bson:"time"`
+		}
+
+		p := PStruct{Time: primitive.Timestamp{T: uint32(nano), I: 123}}
+		b := BStruct{Time: MongoTimestamp((nano << 32) + 123)}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		type PStruct struct {
+			Time *primitive.Timestamp `bson:"time"`
+		}
+
+		type BStruct struct {
+			Time *MongoTimestamp `bson:"time"`
+		}
+
+		p := PStruct{Time: &primitive.Timestamp{T: uint32(nano), I: 123}}
+
+		ts := MongoTimestamp((nano << 32) + 123)
+		b := BStruct{Time: &ts}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
+
+	t.Run("pointer omitempty", func(t *testing.T) {
+		type PStruct struct {
+			Time *primitive.Timestamp `bson:"time,omitempty"`
+		}
+
+		type BStruct struct {
+			Time *MongoTimestamp `bson:"time,omitempty"`
+		}
+
+		p := PStruct{Time: &primitive.Timestamp{T: uint32(nano), I: 123}}
+
+		ts := MongoTimestamp((nano << 32) + 123)
+		b := BStruct{Time: &ts}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
+
+	t.Run("pointer omitempty nil", func(t *testing.T) {
+		type PStruct struct {
+			Time *primitive.Timestamp `bson:"time,omitempty"`
+		}
+
+		type BStruct struct {
+			Time *MongoTimestamp `bson:"time,omitempty"`
+		}
+
+		p := PStruct{}
+		b := BStruct{}
+
+		CheckMarshalAndUnmarshal(t, p, b)
+	})
+}
+
 func TestMarshal_M(t *testing.T) {
 	t.Run("basic key value", func(t *testing.T) {
 		p := primitive.M{"name": "abc"}


### PR DESCRIPTION
bson.MongoTimestamp and primitive.Timestamp need be supported by both drivers.