### PR TITLE
decode nil into empty primitive.ObjectID

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -575,8 +575,12 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 	}
 
 	if outt == typePrimObjectId {
-		inv := reflect.ValueOf(in)
-		reflect.Copy(out, inv)
+		if in == nil {
+			out.SetZero()
+		} else {
+			inv := reflect.ValueOf(in)
+			reflect.Copy(out, inv)
+		}
 		return true
 	}
 

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -120,13 +120,19 @@ func TestMarshal_ObjectID(t *testing.T) {
 		// should error for new type
 		{
 			// old driver
-			var s2 Struct2
+			s2 := Struct2{
+				ID: primitive.NewObjectID(),
+			}
 			err = Unmarshal(data, &s2)
-			assert.Error(t, err)
+			assert.NoError(t, err)
+
+			assert.Equal(t, primitive.NilObjectID, s2.ID)
 		}
 
 		{
 			// new driver
+			// NOTE: nulls can not be unmarshaled into non-pointer types
+			// with the new driver, this could become a problem for us.
 			var s2 Struct2
 			err = bson.Unmarshal(data, &s2)
 			assert.Error(t, err)


### PR DESCRIPTION
if the bson/mongo data is `{ some_id: nil }` unmarshalling into `primitive.ObjectID`  would fail. We just want it to be empty, like what would happen for `bson.ObjectID`.

